### PR TITLE
core: string: Unsigned difference expression compared to zero

### DIFF
--- a/src/core/string.c
+++ b/src/core/string.c
@@ -826,7 +826,7 @@ dom_exception dom_string_replace(dom_string *target,
 	}
 
 	/* Copy remainder of target, if any, into result */
-	if (tlen - b2 > 0) {
+	if (b2 < tlen) {
 		memcpy(res->data.cdata.ptr + b1 + slen, t + b2, tlen - b2);
 	}
 


### PR DESCRIPTION
Squash CodeQL `cpp/unsigned-difference-expression-compared-zero` issue.

    This rule finds relational comparisons between the result of
    an unsigned subtraction and the value `0`. Such comparisons
    are likely to be wrong as the value of an unsigned subtraction
    can never be negative. So the relational comparison ends up
    checking whether the result of the subtraction is equal to 0.
    This is probably not what the programmer intended.